### PR TITLE
Add support for optional CLI flags in 'uv sync'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The action requires a pyproject.toml file to be present in the repository.
 | `py-version`      | Version of Python used to execute the tests.                                |   Yes    |    -     |
 | `ffmpeg-required` | Determines if FFMPEG installation is needed.                                |    No    | `false`  |
 | `test-path`       | Directory containing the test files.                                        |    No    | `tests/` |
-| `uv-sync-args`    | Optional CLI flags passed to "uv sync" (e.g., `--extra opt1 --extra opt2`). |    No    | `""`    |
+| `uv-sync-args`    | Optional CLI flags passed to "uv sync" (e.g., `--extra opt1 --extra opt2`). |    No    |   `""`   |
 
 ## 📦 Usage Example
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ The action requires a pyproject.toml file to be present in the repository.
 
 ## ⚙️ Inputs
 
-| Name              | Description                                                    | Required | Default  |
-| ----------------- | -------------------------------------------------------------- | :------: | :------: |
-| `package-path`    | Specifies the Python package directory for coverage reporting. |   Yes    |    -     |
-| `py-version`      | Version of Python used to execute the tests.                   |   Yes    |    -     |
-| `ffmpeg-required` | Determines if FFMPEG installation is needed.                   |    No    | `false`  |
-| `test-path`       | Directory containing the test files.                           |    No    | `tests/` |
+| Name              | Description                                                                 | Required | Default  |
+| ----------------- | --------------------------------------------------------------------------- | :------: | :------: |
+| `package-path`    | Specifies the Python package directory for coverage reporting.              |   Yes    |    -     |
+| `py-version`      | Version of Python used to execute the tests.                                |   Yes    |    -     |
+| `ffmpeg-required` | Determines if FFMPEG installation is needed.                                |    No    | `false`  |
+| `test-path`       | Directory containing the test files.                                        |    No    | `tests/` |
+| `uv-sync-args`    | Optional CLI flags passed to "uv sync" (e.g., `--extra opt1 --extra opt2`). |    No    | `""`    |
 
 ## 📦 Usage Example
+
+Note: By default, this action no longer installs all optional extras. To install specific optional dependencies, pass them explicitly via `uv-sync-args` (e.g., `--extra optional_deps_1 --extra optional_deps_2`).
 
 Use this action by creating a workflow file, for example: `.github/workflows/test.yml`:
 
@@ -54,6 +57,7 @@ jobs:
           package-path: my-package-name
           test-path: tests
           ffmpeg-required: true
+          uv-sync-args: "--extra opt1 --extra opt2"
 ```
 
 ## 🆕 Create a new release

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Directory containing the test files."
     required: false
     default: tests/
+  uv-sync-args:
+    description: "Optional CLI flags passed to 'uv sync' (e.g., '--extra opt1 --extra opt2')."
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -34,7 +38,7 @@ runs:
         enable-cache: true
     - name: Install the project
       shell: bash
-      run: uv sync --locked --all-extras --dev
+      run: uv sync --locked --dev ${{ inputs.uv-sync-args }}
     - name: Linting
       shell: bash
       run: uv run flake8 .


### PR DESCRIPTION
This pull request introduces the ability to use optional CLI flags in the `uv sync` command by utilizing the `uv-sync-args` input. This enhancement allows for greater flexibility and customization when executing the command.

OP#8495