### PR TITLE
Update GitHub action usage example to version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Python Tests
-        uses: platomo/test-python-app-action@v1
+        uses: platomo/test-python-app-action@v3
         timeout-minutes: 60
         with:
           py-version: ${{ matrix.py }}


### PR DESCRIPTION
Update the example in the documentation to reflect the new version (v3) of the GitHub action. This ensures users reference the latest and correct version.